### PR TITLE
Allow up to 300% magnification of cards instead only 150%

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -76,7 +76,7 @@
         <com.ichi2.ui.SeekBarPreference
             android:defaultValue="100"
             android:key="cardZoom"
-            android:max="150"
+            android:max="300"
             android:summary="@string/preference_summary_percentage"
             android:text=" %"
             android:title="@string/card_zoom"


### PR DESCRIPTION
Some non-Latin languages show up very small on screens. A 300% magnification allows comfortable reading without any stylesheet modifications.